### PR TITLE
Add optional attempt number to robograding/testing.

### DIFF
--- a/group_project.py
+++ b/group_project.py
@@ -585,6 +585,14 @@ class HandlerData:
                     request_and_responses.responses[response_key] = issue_data
         return result
 
+    def requests_and_responses_handled(self):
+        def f():
+            for request_and_responses in self.requests_and_responses.values():
+                if request_and_responses.handled:
+                    yield request_and_responses
+
+        return tuple(f())
+
     def process_requests(self):
         '''
         Process requests.


### PR DESCRIPTION
* Add convenience method HandlerData.requests_and_responses_handled.
* Refactor testing handler via robograding handler.
* Set format_count in robograding/testing handlers to prefix attempt number to response issue.

Fixed #1. Can be enabled in lab config by setting format_count(n) = 'whatever' in test tag handler.